### PR TITLE
Use metaprogramming

### DIFF
--- a/lib/batch_loader/executor.rb
+++ b/lib/batch_loader/executor.rb
@@ -16,10 +16,11 @@ class BatchLoader
       Thread.current[NAMESPACE] = nil
     end
 
-    attr_reader :items_by_block, :loaded_values_by_block
+    attr_reader :items_by_block, :loaded_values_by_block, :context_by_block
 
     def initialize
       @items_by_block = Hash.new { |hash, key| hash[key] = Set.new }
+      @context_by_block = Hash.new { |hash, key| hash[key] = {} }
       @loaded_values_by_block = Hash.new { |hash, key| hash[key] = {} }
     end
   end

--- a/lib/batch_loader/executor_proxy.rb
+++ b/lib/batch_loader/executor_proxy.rb
@@ -6,10 +6,10 @@ class BatchLoader
   class ExecutorProxy
     attr_reader :default_value, :block, :global_executor
 
-    def initialize(default_value, slug, &block)
+    def initialize(default_value, key, &block)
       @default_value = default_value
       @block = block
-      @block_hash_key = slug || block.source_location
+      @block_hash_key = key || block.source_location
       @global_executor = BatchLoader::Executor.ensure_current
     end
 

--- a/lib/batch_loader/executor_proxy.rb
+++ b/lib/batch_loader/executor_proxy.rb
@@ -6,14 +6,15 @@ class BatchLoader
   class ExecutorProxy
     attr_reader :default_value, :block, :global_executor
 
-    def initialize(default_value, &block)
+    def initialize(default_value, slug, &block)
       @default_value = default_value
       @block = block
-      @block_hash_key = block.source_location
+      @block_hash_key = slug || block.source_location
       @global_executor = BatchLoader::Executor.ensure_current
     end
 
-    def add(item:)
+    def add(item:, context:)
+      context_to_load[item] = context
       items_to_load << item
     end
 
@@ -21,7 +22,12 @@ class BatchLoader
       items_to_load.to_a
     end
 
+    def list_context
+      context_to_load
+    end
+
     def delete(items:)
+      items.each { |value| global_executor.context_by_block[@block_hash_key].delete(value) }
       global_executor.items_by_block[@block_hash_key] = items_to_load - items
     end
 
@@ -49,6 +55,10 @@ class BatchLoader
 
     def items_to_load
       global_executor.items_by_block[@block_hash_key]
+    end
+
+    def context_to_load
+      global_executor.context_by_block[@block_hash_key]
     end
 
     def loaded

--- a/spec/fixtures/models.rb
+++ b/spec/fixtures/models.rb
@@ -34,26 +34,26 @@ class Post
   end
 end
 
-class User
+class ResourceBase
   class << self
     def save(id:)
       ensure_init_store
-      @users[id] = new(id: id)
+      @resources[id] = new(id: id)
     end
 
     def where(id:)
       ensure_init_store
-      @users.each_with_object([]) { |(k, v), memo| memo << v if id.include?(k) }
+      @resources.each_with_object([]) { |(k, v), memo| memo << v if id.include?(k) }
     end
 
     def destroy_all
-      @users = {}
+      @resources = {}
     end
 
     private
 
     def ensure_init_store
-      @users ||= {}
+      @resources ||= {}
     end
   end
 
@@ -62,7 +62,9 @@ class User
   def initialize(id:)
     @id = id
   end
+end
 
+class User < ResourceBase
   def batch
     "Batch from User"
   end
@@ -72,4 +74,7 @@ class User
   def some_private_method
     :some_private_method
   end
+end
+
+class Role < ResourceBase
 end


### PR DESCRIPTION
An Example:
```ruby
meta_programming = {
  user: { name: 'User', ids: [1, 2, 3], items: [] },
  role: { name: 'Role', ids: [1, 2, 4, 5], items: [] },
}.each do |type, kind|
  kind[:ids].map do |id|
    kind[:items] << BatchLoader.for(id, type, kind).batch do |ids, loader, slug, context|
      Object.const_get(slug.capitalize).where(id: ids).each { |item| loader.call(item.id, item) }
    end
  end
end
```

For example in GraphQL:

```ruby
associations = model.reflections
...
associations.each do |name, association|
  slug = "#{model_name}:#{name}"
  ...
  BatchLoader.for(obj.send(association.active_record_primary_key), slug).batch(cache: true) do |keys, loader, slug_return|
    association = storage[slug_return]
    foreign_key = association.foreign_key
    association.klass.where({foreign_key => keys}).each { |item| loader.call(item.send(foreign_key), item) }
  end
end
```

The secret is here, because block.source_location doesn’t work well when using metaprogramming
```ruby
@block_hash_key = slug || block.source_location
```