### PR TITLE
Do not depend on #method_missing for #respond_to?

### DIFF
--- a/lib/batch_loader.rb
+++ b/lib/batch_loader.rb
@@ -36,7 +36,9 @@ class BatchLoader
   end
 
   def respond_to?(method_name, include_private = false)
-    LEFT_INSTANCE_METHODS.include?(method_name) || method_missing(:respond_to?, method_name, include_private)
+    return true if LEFT_INSTANCE_METHODS.include?(method_name)
+
+    __loaded_value.respond_to?(method_name, include_private)
   end
 
   def inspect
@@ -59,6 +61,11 @@ class BatchLoader
   end
 
   private
+
+  def __loaded_value
+    result = __sync!
+    @cache ? @loaded_value : result
+  end
 
   def method_missing(method_name, *args, &block)
     __sync!.public_send(method_name, *args, &block)


### PR DESCRIPTION
After the object is batch loaded, the original method_missing
implementation is not called anymore after a `__replace_with!` call.

When `respond_to?` is called on the loaded object afterwords this will
call `#method_missing` on the loaded object. However, the loaded object
can itself have an implementation of method_missing, in this case only
to determine if it responds to a symbol.

Other than the current implementation, the `#method_missing` could be
listed in `IMPLEMENTED_INSTANCE_METHODS`, so it won't be rerouted to the
lazy loaded object. This however calls `__sync!` again, with the
overhead that entails.

Detected this behaviour first for #4, but that was the wrong patch.