### PR TITLE
Identify item by key object instead of key string representation

### DIFF
--- a/lib/batch_loader/executor_proxy.rb
+++ b/lib/batch_loader/executor_proxy.rb
@@ -9,7 +9,7 @@ class BatchLoader
     def initialize(default_value, key, &block)
       @default_value = default_value
       @block = block
-      @block_hash_key = "#{key}#{block.source_location}"
+      @block_hash_key = [block.source_location, key]
       @global_executor = BatchLoader::Executor.ensure_current
     end
 

--- a/spec/fixtures/models.rb
+++ b/spec/fixtures/models.rb
@@ -1,10 +1,10 @@
 class Post
-  attr_accessor :user_id
+  attr_accessor :user_id, :title
 
   class << self
-    def save(user_id:)
+    def save(user_id:, title: nil)
       ensure_init_store
-      @posts << new(user_id: user_id)
+      new(user_id: user_id, title: title).tap { |post| @posts << post }
     end
 
     def all
@@ -23,8 +23,9 @@ class Post
     end
   end
 
-  def initialize(user_id:)
+  def initialize(user_id:, title: nil)
     self.user_id = user_id
+    self.title = title || "Untitled"
   end
 
   def user_lazy(cache: true)
@@ -66,6 +67,18 @@ class User
 
   def batch
     "Batch from User"
+  end
+
+  def hash
+    [User, id].hash
+  end
+
+  def posts
+    Post.all.select { |p| p.user_id == id }
+  end
+
+  def eql?(other)
+    other.is_a?(User) && id == other.id
   end
 
   private


### PR DESCRIPTION
Imagine I have the following code:

```ruby
class File < ActiveRecord::Base
  belongs_to :project

  def self.lazy(project, file_name)
    BatchLoader.for(file_name).batch(key: project) do |file_names, loader, args|
      args[:key].files.where(name: file_names).each do |file|
        loader.call(file.name, file)
      end
    end
  end
end

project = Project.first
same_project = Project.find(project.id)

file_a = File.lazy(project, "file_a")
file_b = File.lazy(same_project, "file_b")
```

Right now, calling `file_a.name` followed by `file_b.name` will result in two queries being executed, because the string representations of `project` and `same_project` are different (they contain the actual Ruby `object_id`), which means the `block_hash_key`s will be different as well.

With the change in this PR, calling `file_a.name` followed by `file_b.name` will result in only one batch query being executed, since `project` and `same_project` have the same `#hash` and implement `#eql?` to regard each other as identical, which means the `block_hash_key`s will be identical for hash keying purposes.

In this specific example, I could also have used `key: project.id` and called `File.where(project_id: args[:key], name: file_names)` instead of `args[:key].files.where(name: file_names)`, but that is not an option in some of the batch loaders in the GitLab code base.

In general, I think it makes sense for BatchLoader to follow the same equality rules here that Ruby usually would if the user has specifically overwritten `#hash` and `#eql?`.