### PR TITLE
Make BatchLoader work with the latest GraphQL versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,13 +258,13 @@ query = "
 Schema.execute(query)
 ```
 
-To avoid this problem, all we have to do is to change the resolver to return `BatchLoader`:
+To avoid this problem, all we have to do is to change the resolver to return `BatchLoader::GraphQL` ([#32](https://github.com/exAspArk/batch-loader/pull/32) explains why not just `BatchLoader`):
 
 ```ruby
 PostType = GraphQL::ObjectType.define do
   name "Post"
   field :user, !UserType, resolve: ->(post, args, ctx) do
-    BatchLoader.for(post.user_id).batch do |user_ids, loader|
+    BatchLoader::GraphQL.for(post.user_id).batch do |user_ids, loader|
       User.where(id: user_ids).each { |user| loader.call(user.id, user) }
     end
   end

--- a/lib/batch_loader/graphql.rb
+++ b/lib/batch_loader/graphql.rb
@@ -2,18 +2,9 @@
 
 class BatchLoader
   class GraphQL
-    class Wrapper
-      def initialize(batch_loader)
-        @batch_loader = batch_loader
-      end
-
-      def sync
-        @batch_loader.__sync
-      end
-    end
-
     def self.use(schema_definition)
-      schema_definition.lazy_resolve(BatchLoader::GraphQL::Wrapper, :sync)
+      schema_definition.lazy_resolve(BatchLoader::GraphQL, :sync)
+      # for graphql gem versions <= 1.8.6 which work with BatchLoader instead of BatchLoader::GraphQL
       schema_definition.instrument(:field, self)
     end
 
@@ -21,10 +12,35 @@ class BatchLoader
       old_resolve_proc = field.resolve_proc
       new_resolve_proc = ->(object, arguments, context) do
         result = old_resolve_proc.call(object, arguments, context)
-        result.respond_to?(:__sync) ? BatchLoader::GraphQL::Wrapper.new(result) : result
+        result.respond_to?(:__sync) ? BatchLoader::GraphQL.wrap(result) : result
       end
 
       field.redefine { resolve(new_resolve_proc) }
+    end
+
+    def self.wrap(batch_loader)
+      BatchLoader::GraphQL.new.tap do |graphql|
+        graphql.batch_loader = batch_loader
+      end
+    end
+
+    def self.for(item)
+      new(item)
+    end
+
+    attr_writer :batch_loader
+
+    def initialize(item = nil)
+      @batch_loader = BatchLoader.for(item)
+    end
+
+    def batch(*args, &block)
+      @batch_loader.batch(*args, &block)
+      self
+    end
+
+    def sync
+      @batch_loader.__sync
     end
   end
 end

--- a/spec/fixtures/models.rb
+++ b/spec/fixtures/models.rb
@@ -84,7 +84,6 @@ class User
   private
 
   def some_private_method
-    :some_private_method
   end
 end
 

--- a/spec/graphql_spec.rb
+++ b/spec/graphql_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe 'GraphQL integration' do
       {
         posts {
           user { id }
-          userId
+          userOld { id }
         }
       }
     QUERY
 
-    expect(User).to receive(:where).with(id: ["1", "2"]).once.and_call_original
+    expect(User).to receive(:where).with(id: ["1", "2"]).twice.and_call_original
 
     result = GraphqlSchema.execute(query)
 
     expect(result['data']).to eq({
       'posts' => [
-        {'user' => {'id' => "1"}, "userId" => 1},
-        {'user' => {'id' => "2"}, "userId" => 2}
+        {'user' => {'id' => "1"}, 'userOld' => {'id' => "1"}},
+        {'user' => {'id' => "2"}, 'userOld' => {'id' => "2"}}
       ]
     })
   end


### PR DESCRIPTION
TL;DR

* If you use `graphql` gem version `1.8.6` or lower, you can continue using `BatchLoader`.
* If you use `graphql` gem version `1.8.7` or greater, you need to replace `BatchLoader.for` with `BatchLoader::GraphQL.for` to make it work within your GraphQL resolvers (methods).

---

Since version [v1.0.0](https://github.com/exAspArk/batch-loader/blob/master/CHANGELOG.md#v100--2017-08-21), `BatchLoader` behaves as a lazy object. It only starts batching when it needs to resolve the values:

```ruby
batch_loader = BatchLoader.for(1).batch(default_value: :foo) { puts "batching..." }
# => #<BatchLoader:0x140623647733240>

batch_loader.class
# batching...
# => Symbol

puts batch_loader
# foo
# => nil
```

At the same time, `graphql-ruby` gem implements a general adapter interface for different [lazy execution](https://github.com/rmosolgo/graphql-ruby/blob/75c3529177474c8e65fd175f0c36fdc2fac185b1/guides/schema/lazy_execution.md) mechanisms. This interface relies on an instance [class](https://github.com/rmosolgo/graphql-ruby/blob/75c3529177474c8e65fd175f0c36fdc2fac185b1/lib/graphql/execution/lazy/lazy_method_map.rb#L36) method to detect whether an object is lazy or not. Unfortunately, since calling `batch_loader.class` tries to resolve the values, it is being resolved with N+1 queries by `graphql-ruby` gem itself.

```ruby
batch_loader.class
# batching...
# => Symbol
```

I [suggested](https://github.com/rmosolgo/graphql-ruby/pull/1784#issuecomment-417736649) a few other potentially more flexible solutions for `graphql-ruby` to detect lazy objects such as duck typing or using explicit arguments. But it looks like it won't be implemented. To fix the issue `BatchLoader` started wrapping `BatchLoader` objects with PORO (plain old ruby objects) by using `graphql-ruby` [instrumentation](https://github.com/rmosolgo/graphql-ruby/blob/75c3529177474c8e65fd175f0c36fdc2fac185b1/guides/fields/instrumentation.md).

This simple `BatchLoader` object wrapping stopped working since `graphql-ruby` version `1.8.7`. This version introduced a breaking change and [started detecting](https://github.com/rmosolgo/graphql-ruby/issues/1778#issuecomment-413331301) lazy objects before the instrumentation. 

In order to fix the compatibility again, this PR introduces `BatchLoader::GraphQL` - a simple PORO with extra 20 lines of code to wrap `BatchLoader` without relying on `graphql-ruby` instrumentation. For example:

```ruby
class PostType < GraphQL::Schema::Object
  field :user, UserType, null: false

  def user
    BatchLoader::GraphQL.for(object.user_id).batch do |user_ids, loader|
      User.where(id: user_ids).each { |user| loader.call(user.id, user) }
    end
  end
end
```

---

Related to https://github.com/rmosolgo/graphql-ruby/issues/1778. Fixes https://github.com/exAspArk/batch-loader/issues/22, https://github.com/exAspArk/batch-loader/issues/26, https://github.com/exAspArk/batch-loader/issues/30.
