### PR TITLE
Fix keyword arguments

### DIFF
--- a/lib/batch_loader.rb
+++ b/lib/batch_loader.rb
@@ -97,10 +97,10 @@ class BatchLoader
 
   def __loader
     mutex = Mutex.new
-    -> (item, value = (no_value = true; nil), &block) do
-      if no_value && !block
-        raise ArgumentError, "Please pass a value or a block"
-      elsif block && !no_value
+    -> (item, value = nil, &block) do
+      if !item
+        raise ArgumentError, "Please pass an item"
+      elsif block && value
         raise ArgumentError, "Please pass a value or a block, not both"
       end
 

--- a/spec/batch_loader_spec.rb
+++ b/spec/batch_loader_spec.rb
@@ -191,9 +191,9 @@ RSpec.describe BatchLoader do
       expect { lazy.sync }.to raise_error(ArgumentError)
     end
 
-    it 'raises ArgumentError if called without block and value' do
+    it 'raises ArgumentError if called without an item' do
       lazy = BatchLoader.for(1).batch do |nums, loader|
-        nums.each { |num| loader.call(num) }
+        nums.each { |_| loader.call }
       end
 
       expect { lazy.sync }.to raise_error(ArgumentError)


### PR DESCRIPTION
Attempt to fix #33 

If there is only an item, this case is valid, else raise exception for missing argument.
Elsif both block && value are present, raise exception for having too many arguments.
Elsif both block && value are missing, this is valid case.
Else either block and value are present, this is a valid case.

Also, the spec `works even if the loaded values is nil` doesn't seems to be valid, because User.where returns empty array, so the loader block is never called. This seems to be the reason why this bug got slipped.