### PR TITLE
Add `replace_methods` argument to BatchLoader#batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ that you can set version constraints properly.
 
 #### [Unreleased](https://github.com/exAspArk/batch-loader/compare/v1.3.0...HEAD)
 
-* WIP
+* `Added`: new `replace_methods` argument to `BatchLoader#batch` to allow control over `define_method` calls
 
 #### [v1.3.0](https://github.com/exAspArk/batch-loader/compare/v1.2.2...v1.3.0)
 

--- a/spec/batch_loader_spec.rb
+++ b/spec/batch_loader_spec.rb
@@ -239,9 +239,9 @@ RSpec.describe BatchLoader do
       expect(subject).to respond_to(:id)
     end
 
-    context 'when the cache is disabled' do
+    context 'when the cache and method replacement is disabled' do
       it 'syncs the object on every call' do
-        loaded_user = post.user_lazy(cache: false)
+        loaded_user = post.user_lazy(cache: false, replace_methods: false)
 
         expect(User).to receive(:where).with(id: [1]).twice.and_call_original
 
@@ -273,15 +273,25 @@ RSpec.describe BatchLoader do
       expect(post.user_lazy(cache: false)).to eq(user2)
     end
 
-    it 'works without cache for the same BatchLoader instance' do
+    it 'works without cache and method replacement for the same BatchLoader instance' do
       user = User.save(id: 1)
       post = Post.new(user_id: user.id)
-      user_lazy = post.user_lazy(cache: false)
+      user_lazy = post.user_lazy(cache: false, replace_methods: false)
 
       expect(User).to receive(:where).with(id: [1]).twice.and_call_original
 
       expect(user_lazy).to eq(user)
       expect(user_lazy).to eq(user)
+    end
+
+    it 'does not replace methods when replace_methods is false' do
+      user = User.save(id: 1)
+      post = Post.new(user_id: user.id)
+      user_lazy = post.user_lazy(cache: true, replace_methods: false)
+
+      expect(user_lazy).to receive(:method_missing).and_call_original
+
+      user_lazy.id
     end
 
     it 'raises the error if something went wrong in the batch' do

--- a/spec/benchmarks/caching.rb
+++ b/spec/benchmarks/caching.rb
@@ -1,0 +1,63 @@
+# Usage: ruby spec/benchmarks/caching.rb
+
+# no replacement + many methods _can_ be faster than replacement + many
+# methods, but this depends on the values of METHOD_COUNT, OBJECT_COUNT,
+# and CALL_COUNT, so tweak them for your own scenario!
+
+require 'benchmark'
+require_relative '../../lib/batch_loader'
+
+METHOD_COUNT = 1000 # methods on the object with a large interface
+OBJECT_COUNT = 1000 # objects in the batch
+CALL_COUNT = 1000 # times a method is called on the loaded object
+
+class ManyMethods
+  1.upto(METHOD_COUNT) do |i|
+    define_method("method_#{i}") { i }
+  end
+end
+
+class FewMethods
+  def method_1
+    1
+  end
+end
+
+def load_value(x, **opts)
+  BatchLoader.for(x).batch(opts) do |xs, loader|
+    xs.each { |x| loader.call(x, x) }
+  end
+end
+
+def benchmark(klass:, **opts)
+  OBJECT_COUNT.times do
+    value = load_value(klass.new, opts)
+    CALL_COUNT.times { value.method_1 }
+  end
+end
+
+Benchmark.bmbm do |x|
+  x.report('replacement + many methods') { benchmark(klass: ManyMethods) }
+  x.report('replacement + few methods') { benchmark(klass: FewMethods) }
+  x.report('no replacement + many methods') { benchmark(klass: ManyMethods, replace_methods: false) }
+  x.report('no replacement + few methods') { benchmark(klass: FewMethods, replace_methods: false) }
+  x.report('no cache + many methods') { benchmark(klass: ManyMethods, cache: false, replace_methods: false) }
+  x.report('no cache + few methods') { benchmark(klass: FewMethods, cache: false, replace_methods: false) }
+end
+
+# Rehearsal -----------------------------------------------------------------
+# replacement + many methods      2.260000   0.030000   2.290000 (  2.603038)
+# replacement + few methods       0.450000   0.000000   0.450000 (  0.457151)
+# no replacement + many methods   0.440000   0.010000   0.450000 (  0.454444)
+# no replacement + few methods    0.370000   0.000000   0.370000 (  0.380699)
+# no cache + many methods        31.780000   0.240000  32.020000 ( 33.552620)
+# no cache + few methods         31.510000   0.200000  31.710000 ( 32.294752)
+# ------------------------------------------------------- total: 67.290000sec
+
+#                                     user     system      total        real
+# replacement + many methods      2.330000   0.010000   2.340000 (  2.382599)
+# replacement + few methods       0.430000   0.000000   0.430000 (  0.438584)
+# no replacement + many methods   0.420000   0.000000   0.420000 (  0.434069)
+# no replacement + few methods    0.440000   0.010000   0.450000 (  0.452091)
+# no cache + many methods        31.630000   0.160000  31.790000 ( 32.337531)
+# no cache + few methods         36.590000   0.370000  36.960000 ( 40.701712)

--- a/spec/fixtures/models.rb
+++ b/spec/fixtures/models.rb
@@ -28,8 +28,8 @@ class Post
     self.title = title || "Untitled"
   end
 
-  def user_lazy(cache: true)
-    BatchLoader.for(user_id).batch(cache: cache) do |user_ids, loader|
+  def user_lazy(**opts)
+    BatchLoader.for(user_id).batch(**opts) do |user_ids, loader|
       User.where(id: user_ids).each { |user| loader.call(user.id, user) }
     end
   end


### PR DESCRIPTION
The existing `cache` argument does two things:

1. `#__sync` uses it to set a `@synced` instance variable, which tells
   later calls to `#__sync` not to reload the value when another method is
   called on it.
2. `#__sync!` uses it to replace methods on the proxied object with
   their 'real' equivalents.

This delegates responsibility for item 2 to the new `replace_methods`
argument instead. In testing (and in the benchmarks added here) we've
seen that `#__replace_with!` can actually take up an appreciable amount
of time, and removing it is faster, even though each individual method
call is slower.

The default for this new argument is to match `cache`. Only if it's
explicitly set to `true` or `false` will it not do that, and if it is
set to `true` and `cache` is `false` we raise an error, because that
doesn't make sense.

Closes https://github.com/exAspArk/batch-loader/issues/43.