### PR TITLE
Improvements to docs for loading multiple items

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ BatchLoader.for(post.user_id).batch(default_value: NullUser.new) do |user_ids, l
 end
 ```
 
-For batches where the value is some kind of collection, such as an Array or Hash, `loader` also supports being called with a block, which yields the _current_ value, and returns the _next_ value. This is extremely useful for 1:Many relationships:
+For batches where the value is some kind of collection, such as an Array or Hash, `loader` also supports being called with a block, which yields the _current_ value, and returns the _next_ value. This is extremely useful for 1:Many (`has_many`) relationships:
 
 ```ruby
 BatchLoader.for(user.id).batch(default_value: []) do |user_ids, loader|


### PR DESCRIPTION
Up for discussion! These changes would have definitely helped me understand how to use this library as a Rails developer. 

- `memo` is a strange term to me—is it referring to memoization? If so, how does that fit here? It doesn't seem immediately obvious to me, but I'm admittedly not the brightest mind!  
- mentioning `has_many` will help both in-page searchability and make it more easily googleable, for rails developers who are accustomed to that terminology

