### PR TITLE
CI: catch up with the last rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,25 @@ matrix:
       rvm: 2.3.8
     - gemfile: graphql-1.7.gemfile
       env: GRAPHQL_RUBY_VERSION=1_7 CI=true
-      rvm: 2.4.5
+      rvm: 2.4.9
     - gemfile: graphql-1.8.gemfile
       env: GRAPHQL_RUBY_VERSION=1_8 CI=true
-      rvm: 2.4.5
+      rvm: 2.4.9
     - gemfile: graphql-1.7.gemfile
       env: GRAPHQL_RUBY_VERSION=1_7 CI=true
-      rvm: 2.5.3
+      rvm: 2.5.7
     - gemfile: graphql-1.8.gemfile
       env: GRAPHQL_RUBY_VERSION=1_8 CI=true
-      rvm: 2.5.3
+      rvm: 2.5.7
+    - gemfile: graphql-1.7.gemfile
+      env: GRAPHQL_RUBY_VERSION=1_7 CI=true
+      rvm: 2.6.5
+    - gemfile: graphql-1.8.gemfile
+      env: GRAPHQL_RUBY_VERSION=1_8 CI=true
+      rvm: 2.6.5
+    - gemfile: graphql-1.7.gemfile
+      env: GRAPHQL_RUBY_VERSION=1_7 CI=true
+      rvm: 2.7.0
+    - gemfile: graphql-1.8.gemfile
+      env: GRAPHQL_RUBY_VERSION=1_8 CI=true
+      rvm: 2.7.0

--- a/spec/batch_loader_spec.rb
+++ b/spec/batch_loader_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe BatchLoader do
         items.map! { |i| i - 1 }
       end
 
-      expect { batch_loader.to_s }.to raise_error(RuntimeError, "can't modify frozen Array")
+      expect { batch_loader.to_s }.to raise_error(RuntimeError, /\Acan't modify frozen Array/)
     end
 
     it 'raises the error if something went wrong in the batch' do


### PR DESCRIPTION
This is a small chore to update Ruby versions for CI.

I also noticed a test case would start to fail for >= Ruby 2.7, due to a change around FrozenError message (ref: https://bugs.ruby-lang.org/issues/15883).

(by the way thanks for the awesome project! We found this dependence-free gem really useful to work on our graphql project - hope this helps :)