### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ That's it.
 For batches where there is no item in response to a call, we normally return `nil`. However, you can use `:default_value` to return something else instead:
 
 ```ruby
-BatchLoader.for(post.user_id).batch(default_value: NullUser.new) do |user_ids, loader|
+BatchLoader::GraphQL.for(post.user_id).batch(default_value: NullUser.new) do |user_ids, loader|
   User.where(id: user_ids).each { |user| loader.call(user.id, user) }
 end
 ```
@@ -327,7 +327,7 @@ end
 For batches where the value is some kind of collection, such as an Array or Hash, `loader` also supports being called with a block, which yields the _current_ value, and returns the _next_ value. This is extremely useful for 1:Many (`has_many`) relationships:
 
 ```ruby
-BatchLoader.for(user.id).batch(default_value: []) do |user_ids, loader|
+BatchLoader::GraphQL.for(user.id).batch(default_value: []) do |user_ids, loader|
   Comment.where(user_id: user_ids).each do |comment|
     loader.call(comment.user_id) { |memo| memo << comment }
   end


### PR DESCRIPTION
For GraphQL collection batches we have to use BatchLoader::GraphQL instead of normal BatchLoader. I suppose this is just a typo in README =)