### PR TITLE
GraphQL Interpreter

### DIFF
--- a/spec/fixtures/graphql_schema.rb
+++ b/spec/fixtures/graphql_schema.rb
@@ -64,4 +64,13 @@ elsif
     query QueryType
     use BatchLoader::GraphQL
   end
+
+  if defined?(GraphQL::Execution::Interpreter)
+    class GraphqlSchemaWithInterpreter < GraphQL::Schema
+      use GraphQL::Execution::Interpreter
+      use GraphQL::Analysis::AST
+      query QueryType
+      use BatchLoader::GraphQL
+    end
+  end
 end

--- a/spec/graphql_spec.rb
+++ b/spec/graphql_spec.rb
@@ -1,7 +1,22 @@
 require "spec_helper"
 
 RSpec.describe 'GraphQL integration' do
+  after do
+    User.destroy_all
+    Post.destroy_all
+  end
+
   it 'resolves BatchLoader fields lazily' do
+    test(GraphqlSchema)
+  end
+
+  if defined?(GraphqlSchemaWithInterpreter)
+    it 'resolves BatchLoader fields lazily with GraphQL Interpreter' do
+      test(GraphqlSchemaWithInterpreter)
+    end
+  end
+
+  def test(schema)
     user1 = User.save(id: "1")
     user2 = User.save(id: "2")
     Post.save(user_id: user1.id)
@@ -17,7 +32,7 @@ RSpec.describe 'GraphQL integration' do
 
     expect(User).to receive(:where).with(id: ["1", "2"]).twice.and_call_original
 
-    result = GraphqlSchema.execute(query)
+    result = schema.execute(query)
 
     expect(result['data']).to eq({
       'posts' => [


### PR DESCRIPTION
* Fixes using `BatchLoader.for` with the GraphQL Interpreter https://github.com/exAspArk/batch-loader/issues/41
* Deprecates using `BatchLoader.for` in favor of `BatchLoader::GraphQL.for` (or `BatchLoader::GraphQL.wrap` in resolvers)