### PR TITLE
Clear the cache at the beginning of middleware (paranoid)

### DIFF
--- a/lib/batch_loader/middleware.rb
+++ b/lib/batch_loader/middleware.rb
@@ -7,6 +7,8 @@ class BatchLoader
     end
 
     def call(env)
+      BatchLoader::Executor.clear_current
+
       begin
         @app.call(env)
       ensure


### PR DESCRIPTION
We saw recently that controller is trying to render the objects from yet another tenancy, it's just like showing the account data of random user within `My profile` page - serious thing you know )

Fortunately that happened for us in test suite - the cache of batch loader was leaking from the places out from true controller context, such as `:controller` and `:view` unit tests. That was not a production issue but still, it's much calmer to see the cache erased before the controller evaluation - just in case, the price of possible leak is high enough )

In production env the leak can happen still from initializer for instance.