### PR TITLE
Fixed deprectation warning from using ruby 2.7.1

### DIFF
--- a/lib/batch_loader/graphql.rb
+++ b/lib/batch_loader/graphql.rb
@@ -54,8 +54,8 @@ class BatchLoader
       @batch_loader = BatchLoader.for(item)
     end
 
-    def batch(*args, &block)
-      @batch_loader.batch(*args, &block)
+    def batch(*args, **kwargs, &block)
+      @batch_loader.batch(*args, **kwargs, &block)
       self
     end
 


### PR DESCRIPTION
When using Ruby 2.7.1, the gem triggers a `Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call` deprecation warning. This PR resolves the warning. The specs complete without error under Ruby 2.6.4 and 2.7.1