### PR TITLE
Additional Ruby 3 fixes relating to kwarg changes

### DIFF
--- a/lib/batch_loader.rb
+++ b/lib/batch_loader.rb
@@ -69,8 +69,8 @@ class BatchLoader
     @cache ? @loaded_value : result
   end
 
-  def method_missing(method_name, *args, &block)
-    __sync!.public_send(method_name, *args, &block)
+  def method_missing(method_name, *args, **kwargs, &block)
+    __sync!.public_send(method_name, *args, **kwargs, &block)
   end
 
   def __sync!
@@ -120,8 +120,8 @@ class BatchLoader
   def __replace_with!(value)
     __singleton_class.class_eval do
       (value.methods - LEFT_INSTANCE_METHODS).each do |method_name|
-        define_method(method_name) do |*args, &block|
-          value.public_send(method_name, *args, &block)
+        define_method(method_name) do |*args, **kwargs, &block|
+          value.public_send(method_name, *args, **kwargs, &block)
         end
       end
     end


### PR DESCRIPTION
Fixes some failures when using Ruby 3 in situations where it appears a few layers of delegation occur inside other libraries (in this case I was having failures using batch-loader in conjunction with view_component or dry-initializer).

This change passes the current tests on both ruby 3 and previous ruby versions. Sorry for not being able to include a test directly to replicate this issue I haven't dug into exactly what those other gems are doing to trigger this issue but the changes here should be innocent enough to not cause too much alarm I hope! :)