### PR TITLE
Don't sync on #tap

### DIFF
--- a/lib/batch_loader.rb
+++ b/lib/batch_loader.rb
@@ -8,7 +8,7 @@ require_relative "./batch_loader/middleware"
 require_relative "./batch_loader/graphql"
 
 class BatchLoader
-  IMPLEMENTED_INSTANCE_METHODS = %i[object_id __id__ __send__ singleton_method_added __sync respond_to? batch inspect].freeze
+  IMPLEMENTED_INSTANCE_METHODS = %i[object_id __id__ __send__ singleton_method_added __sync respond_to? batch inspect tap].freeze
   REPLACABLE_INSTANCE_METHODS = %i[batch inspect].freeze
   LEFT_INSTANCE_METHODS = (IMPLEMENTED_INSTANCE_METHODS - REPLACABLE_INSTANCE_METHODS).freeze
 

--- a/spec/batch_loader_spec.rb
+++ b/spec/batch_loader_spec.rb
@@ -310,4 +310,12 @@ RSpec.describe BatchLoader do
       expect { result.to_s }.to raise_error("Oops")
     end
   end
+
+  describe '#tap' do
+    it 'returns BatchLoader without syncing' do
+      result = BatchLoader.for(1).batch { |_ids, _loader| raise "Oops" }
+
+      expect { result.tap {} }.not_to raise_error("Oops")
+    end
+  end
 end


### PR DESCRIPTION
Sometimes #tap is used just for code style and the value is never checked, so don't sync the value.

(Contrived) Example:
```ruby
lazy_fetch(1).tap { logger.info 'lazy_fetch complete' }
```