### PR TITLE
Update docs on using `BatchLoader` with `ActiveRecord` in multple places

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ class Types::PreloadableField < Types::BaseField
     return super unless @preloads
 
     BatchLoader::GraphQL.for(type).batch(key: self) do |records, loader|
-      ActiveRecord::Associations::Preloader.new.preload(records.map(&:object), @preloads)
+      ActiveRecord::Associations::Preloader.new(records: records.map(&:object), associations: @preloads).call
       records.each { |r| loader.call(r, super(r, args, ctx)) }
     end
   end


### PR DESCRIPTION
Rails has changed the implementation for ActiveRecord::Associations::Preloader. This makes using BatchLoader with ActiveRecord in multiple places example in the README quite misleading.