### PR TITLE
Add lazy eval

### DIFF
--- a/lib/batch_loader/graphql.rb
+++ b/lib/batch_loader/graphql.rb
@@ -68,8 +68,18 @@ class BatchLoader
       self
     end
 
+    def lazy_eval
+      @batch_loader.lazy_eval
+      self
+    end
+
     def sync
       @batch_loader.__sync
+    end
+
+    def method_missing(method_name, *args, **kwargs, &block)
+      super if !@batch_loader.__accepting_lazy_chain?
+      @batch_loader.public_send(method_name, *args, **kwargs, &block)
     end
   end
 end

--- a/spec/fixtures/graphql_schema.rb
+++ b/spec/fixtures/graphql_schema.rb
@@ -4,12 +4,22 @@ end
 
 class PostType < GraphQL::Schema::Object
   field :user, UserType, null: false
+  field :user_id, String, null: false
+  field :user_name, String, null: false
   field :user_old, UserType, null: false
 
   def user
     BatchLoader::GraphQL.for(object.user_id).batch(default_value: nil) do |user_ids, loader|
       User.where(id: user_ids).each { |user| loader.call(user.id, user) }
     end
+  end
+
+  def user_id
+    user.lazy_eval.id
+  end
+
+  def user_name
+    user.lazy_eval.name
   end
 
   def user_old

--- a/spec/fixtures/models.rb
+++ b/spec/fixtures/models.rb
@@ -37,9 +37,9 @@ end
 
 class User
   class << self
-    def save(id:)
+    def save(id:, name: nil)
       ensure_init_store
-      @store[self][id] = new(id: id)
+      @store[self][id] = new(id: id, name: name)
     end
 
     def where(id:)
@@ -59,14 +59,19 @@ class User
     end
   end
 
-  attr_reader :id
+  attr_reader :id, :name
 
-  def initialize(id:)
+  def initialize(id:, name: nil)
     @id = id
+    @name = name
   end
 
   def batch
     "Batch from User"
+  end
+
+  def lazy_eval
+    "Lazy Eval from User"
   end
 
   def hash

--- a/spec/graphql_spec.rb
+++ b/spec/graphql_spec.rb
@@ -17,14 +17,16 @@ RSpec.describe 'GraphQL integration' do
   end
 
   def test(schema)
-    user1 = User.save(id: "1")
-    user2 = User.save(id: "2")
+    user1 = User.save(id: "1", name: "John")
+    user2 = User.save(id: "2", name: "Jane")
     Post.save(user_id: user1.id)
     Post.save(user_id: user2.id)
     query = <<~QUERY
       {
         posts {
           user { id }
+          userName
+          userId
           userOld { id }
         }
       }
@@ -36,8 +38,8 @@ RSpec.describe 'GraphQL integration' do
 
     expect(result['data']).to eq({
       'posts' => [
-        {'user' => {'id' => "1"}, 'userOld' => {'id' => "1"}},
-        {'user' => {'id' => "2"}, 'userOld' => {'id' => "2"}}
+        {'user' => {'id' => "1"}, 'userOld' => {'id' => "1"}, 'userId' => "1", 'userName' => "John"},
+        {'user' => {'id' => "2"}, 'userOld' => {'id' => "2"}, 'userId' => "2", 'userName' => "Jane"}
       ]
     })
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require 'pry'
 
 if ENV['CI']
   require 'coveralls'


### PR DESCRIPTION
Follow up to this pr: https://github.com/exAspArk/batch-loader/pull/89

Added a `lazy_eval` method to chain methods together.
I called it `lazy_eval` instead of `lazy` to avoid breaking changes.
Follows Enumerator::Lazy with `eager` and `force` methods that only become available after `lazy_eval` is called.
`eager` tells the loader to stop accumulating methods in the lazy chain and force a real evaluation on the next call.
`force` tells the loader to sync immediately (kind of redundant, you shouldn't use lazy_eval if you're gonna force)

In graphql, a sync is implicitly done at the correct time so `eager` isn't required to break the lazy chain. I automatically disable lazy chaining after a sync. This allows a nice looking:
```
def user_name
  user.lazy_eval.name
end
```

But in non graphql contexts, you'd have to do:
```
def lazy_user_name
  user_lazy.lazy_eval.name.eager
end
```

The code is relatively easy to understand, and the api is fairly analogous to Enumerator::Lazy, but I understand if you think it's too complex. Let me know if you have any thoughts, was fun to work on regardless.