### PR TITLE
Allow others to trace `execute_field` GQL event

### DIFF
--- a/lib/batch_loader/graphql.rb
+++ b/lib/batch_loader/graphql.rb
@@ -4,7 +4,7 @@ class BatchLoader
   class GraphQL
     module Trace
       def execute_field(**_data)
-        result = yield
+        result = super
         result.respond_to?(:__sync) ? BatchLoader::GraphQL.wrap_with_warning(result) : result
       end
     end


### PR DESCRIPTION
*Follow-up to https://github.com/exAspArk/batch-loader/pull/91.*

The new tracing API works in a way that modules get included into a `GraphQL::Tracing::Trace` class, which provides a no-op `#execute_field` implementation that just yields. If we don't call `super`, other tracing modules that override `#execute_field` as well, that got included before batch-loader, won't get executed, because `yield` will short-circuit the execution.
