### PR TITLE
Fix wrap_with_warning call for new tracing module

### DIFF
--- a/lib/batch_loader/graphql.rb
+++ b/lib/batch_loader/graphql.rb
@@ -45,7 +45,6 @@ class BatchLoader
       warn "DEPRECATION WARNING: using BatchLoader.for in GraphQL is deprecated. Use BatchLoader::GraphQL.for instead or return BatchLoader::GraphQL.wrap from your resolver."
       wrap(batch_loader)
     end
-    private_class_method :wrap_with_warning
 
     def self.wrap(batch_loader)
       BatchLoader::GraphQL.new.tap do |graphql|


### PR DESCRIPTION
When using the new tracing module, we call `wrap_with_warning` on the class so we should not make this a private method.

This prevents errors like:

```
Internal server error: private method `wrap_with_warning' called for BatchLoader::GraphQL:Class
```