### PR TITLE
prevents double wrapping of `BatchLoader::GraphQL`

### DIFF
--- a/lib/batch_loader/graphql.rb
+++ b/lib/batch_loader/graphql.rb
@@ -47,8 +47,13 @@ class BatchLoader
     end
 
     def self.wrap(batch_loader)
-      BatchLoader::GraphQL.new.tap do |graphql|
-        graphql.batch_loader = batch_loader
+      case batch_loader
+      when BatchLoader::GraphQL
+        batch_loader
+      else
+        BatchLoader::GraphQL.new.tap do |graphql|
+          graphql.batch_loader = batch_loader
+        end
       end
     end
 


### PR DESCRIPTION
This commit updates the behavior of `BatchLoader::GraphQL.wrap` so that
  if the passed in `batch_loader` argument is already a
  `BatchLoader::GrapQL`, we just return it instead of re-wrapping it.

This prevents unexpected errors for downstream clients, such as trying
  to call `__sync` on an instance of a `BatchLoader::GraphQL`.